### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/storage/compact/compact_test.go
+++ b/internal/storage/compact/compact_test.go
@@ -5,8 +5,6 @@ package compact
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -47,13 +45,13 @@ func (w blockWriter) WriteBlock(blocks []block.Block, schema typeof.Schema) erro
 // Opens a new disk storage and runs a a test on it.
 func runTest(t *testing.T, test func(store *disk.Storage)) {
 	assert.NotPanics(t, func() {
-		run(test)
+		run(t, test)
 	})
 }
 
 // Run runs a function on a temp store
-func run(f func(store *disk.Storage)) {
-	dir, _ := ioutil.TempDir("", "test")
+func run(t *testing.T, f func(store *disk.Storage)) {
+	dir := t.TempDir()
 	store := disk.New(monitor.NewNoop())
 	syncWrite := false
 	_ = store.Open(dir, config.Badger{
@@ -61,7 +59,6 @@ func run(f func(store *disk.Storage)) {
 	})
 
 	// Close once we're done and delete data
-	defer func() { _ = os.RemoveAll(dir) }()
 	defer func() { _ = store.Close() }()
 
 	f(store)

--- a/internal/table/log/log_test.go
+++ b/internal/table/log/log_test.go
@@ -5,8 +5,6 @@ package log
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -37,10 +35,7 @@ func (m *mockConfigurer) Configure(c *config.Config) error {
 }
 
 func TestLog(t *testing.T) {
-	dir, err := ioutil.TempDir(".", "testlog-")
-	assert.NoError(t, err)
-
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	cfg := config.Load(context.Background(), 60*time.Second, &mockConfigurer{
 		dir: dir,
@@ -55,8 +50,6 @@ func TestLog(t *testing.T) {
 
 	// Append some files
 	{
-
-		assert.NoError(t, err)
 		assert.NoError(t, logs.Append("hello world", logging.LevelInfo))
 		assert.NoError(t, logs.Append("test message", logging.LevelWarning))
 	}

--- a/internal/table/timeseries/timeseries_test.go
+++ b/internal/table/timeseries/timeseries_test.go
@@ -5,7 +5,6 @@ package timeseries_test
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/kelindar/talaria/internal/config"
@@ -44,8 +43,7 @@ func (m *mockConfigurer) Configure(c *config.Config) error {
 }
 
 func TestTimeseries_DynamicSchema(t *testing.T) {
-	dir, _ := ioutil.TempDir(".", "testdata-")
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	const name = "eventlog"
 	tableConf := config.Table{
@@ -134,8 +132,7 @@ func TestTimeseries_DynamicSchema(t *testing.T) {
 }
 
 func TestTimeSeries_LoadStaticSchema(t *testing.T) {
-	dir, _ := ioutil.TempDir(".", "testdata-")
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := t.TempDir()
 
 	staticSchema := `string1: string
 int1: int64

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -52,9 +51,7 @@ func (m *benchMockConfigurer) Configure(c *config.Config) error {
 // To run it, go in the directory and do 'go test -benchmem -bench=. -benchtime=1s'
 // BenchmarkQuery/query-8         	     194	   6067001 ns/op	34924064 B/op	    1504 allocs/op
 func BenchmarkQuery(b *testing.B) {
-	dir, err := ioutil.TempDir(".", "testdata-")
-	noerror(err)
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := b.TempDir()
 	cfg := config.Load(context.Background(), 60*time.Second, &benchMockConfigurer{dir: dir})
 
 	// create monitor


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	assert.NoError(t, err)
	defer func() { _ = os.RemoveAll(dir) }()

	// now
	tmpDir := t.TempDir()
}
```