### PR TITLE
add grpc call message size configuration

### DIFF
--- a/client/golang/client_opts.go
+++ b/client/golang/client_opts.go
@@ -15,12 +15,21 @@ type Option func(client *Client)
 
 // netconf defines connection pool configuration for a gRPC service
 type netconf struct {
-	CircuitOptions map[string]hystrix.CommandConfig // Circuit configuration
-	Address        string                           // Endpoint of the server
-	DialTimeout    time.Duration                    // Dial timaout
-	Credentials    credentials.TransportCredentials // Transport credentials to use
-	NonBlocking    bool                             // once set to true, the client will be returned before connection gets ready
-	LoadBalancer   string                           // gRPC load balancing strategy
+	CircuitOptions     map[string]hystrix.CommandConfig // Circuit configuration
+	Address            string                           // Endpoint of the server
+	DialTimeout        time.Duration                    // Dial timaout
+	Credentials        credentials.TransportCredentials // Transport credentials to use
+	NonBlocking        bool                             // once set to true, the client will be returned before connection gets ready
+	LoadBalancer       string                           // gRPC load balancing strategy
+	MaxCallRecvMsgSize int                              // Message size of response from server
+	MaxCallSendMsgSize int                              // Message size of client request
+}
+
+func WithMaxMsgSize(maxSendMsgSize, maxRecvMsgSize int) Option {
+	return func(client *Client) {
+		client.netconf.MaxCallRecvMsgSize = maxRecvMsgSize
+		client.netconf.MaxCallSendMsgSize = maxSendMsgSize
+	}
 }
 
 // WithNetwork specifies the configuration for a connection.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,7 +89,9 @@ type Writers struct {
 
 // GRPC represents the configuration for gRPC ingress
 type GRPC struct {
-	Port int32 `json:"port" yaml:"port" env:"PORT"` // The port for the gRPC listener (default: 8080)
+	Port           int32 `json:"port" yaml:"port" env:"PORT"` // The port for the gRPC listener (default: 8080)
+	MaxRecvMsgSize int   `json:"maxRecvMsgSize" yaml:"maxRecvMsgSize" env:"MAXRECVMSGSIZE"`
+	MaxSendMsgSize int   `json:"maxSendMsgSize" yaml:"maxSendMsgSize" env:"MAXSENDMSGSIZE"`
 }
 
 // S3SQS represents the aws S3 SQS configuration
@@ -210,10 +212,12 @@ type PubSubSink struct {
 // TalariaSink represents a sink to an instance of Talaria
 type TalariaSink struct {
 	BaseSink              `yaml:",inline"`
-	Endpoint              string         `json:"endpoint" yaml:"endpoint" env:"ENDPOINT"`                    // The second Talaria endpoint
-	CircuitTimeout        *time.Duration `json:"timeout" yaml:"timeout" env:"TIMEOUT"`                       // The timeout (in seconds) for requests to the second Talaria
-	MaxConcurrent         *int           `json:"concurrency" yaml:"concurrency" env:"CONCURRENCY"`           // The number of concurrent requests permissible
-	ErrorPercentThreshold *int           `json:"errorThreshold" yaml:"errorThreshold" env:"ERROR_THRESHOLD"` // The percentage of failed requests tolerated
+	Endpoint              string         `json:"endpoint" yaml:"endpoint" env:"ENDPOINT"`                               // The second Talaria endpoint
+	CircuitTimeout        *time.Duration `json:"timeout" yaml:"timeout" env:"TIMEOUT"`                                  // The timeout (in seconds) for requests to the second Talaria
+	MaxConcurrent         *int           `json:"concurrency" yaml:"concurrency" env:"CONCURRENCY"`                      // The number of concurrent requests permissible
+	ErrorPercentThreshold *int           `json:"errorThreshold" yaml:"errorThreshold" env:"ERROR_THRESHOLD"`            // The percentage of failed requests tolerated
+	MaxCallRecvMsgSize    *int           `json:"maxCallRecvMsgSize" yaml:"maxCallRecvMsgSize" env:"MAXCALLRECVMSGSIZE"` // The Max message size of gprc call per server response
+	MaxCallSendMsgSize    *int           `json:"maxCallSendMsgSize" yaml:"maxCallSendMsgSize" env:"MAXCALLSENDMSGSIZE"` // The Max message size of gprc call per client request
 }
 
 // Func represents a config function

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,9 +46,17 @@ type Storage interface {
 
 // New creates a new talaria server.
 func New(conf config.Func, monitor monitor.Monitor, tables ...table.Table) *Server {
-	const maxMessageSize = 32 * 1024 * 1024 // 32 MB
+	// Default grpc message size is 32 MB
+	if conf().Writers.GRPC.MaxSendMsgSize == 0 {
+		conf().Writers.GRPC.MaxSendMsgSize = 32 * 1024 * 1024 // 32 MB
+	}
+
+	if conf().Writers.GRPC.MaxRecvMsgSize == 0 {
+		conf().Writers.GRPC.MaxRecvMsgSize = 32 * 1024 * 1024 // 32 MB
+	}
+
 	server := &Server{
-		server:  grpc.NewServer(grpc.MaxRecvMsgSize(maxMessageSize)),
+		server:  grpc.NewServer(grpc.MaxRecvMsgSize(conf().Writers.GRPC.MaxRecvMsgSize), grpc.MaxSendMsgSize(conf().Writers.GRPC.MaxSendMsgSize)),
 		conf:    conf,
 		monitor: monitor,
 		tables:  make(map[string]table.Table),

--- a/internal/storage/writer/talaria/talaria_test.go
+++ b/internal/storage/writer/talaria/talaria_test.go
@@ -15,8 +15,10 @@ func TestTalariaWriter(t *testing.T) {
 	var timeout time.Duration = 5
 	var concurrency int = 10
 	var errorPercentage int = 50
+	var maxSendMsgSize int = 32 * 1024 * 1024
+	var maxRecvMsgSize int = 32 * 1024 * 1024
 	m := monitor.New(logging.NewNoop(), statsd.NewNoop(), "x", "y")
-	c, err := New("www.talaria.net:8043", "", "orc", m, &timeout, &concurrency, &errorPercentage)
+	c, err := New("www.talaria.net:8043", "", "orc", m, &timeout, &concurrency, &errorPercentage, &maxSendMsgSize, &maxRecvMsgSize)
 
 	// TODO: Impove test
 	assert.Nil(t, c)

--- a/internal/storage/writer/writer.go
+++ b/internal/storage/writer/writer.go
@@ -151,7 +151,7 @@ func newWriter(sinks []config.Sink, monitor monitor.Monitor) (flush.Writer, erro
 
 		// Configure Talaria writer if present
 		if config.Talaria != nil {
-			w, err := talaria.New(config.Talaria.Endpoint, config.Talaria.Filter, config.Talaria.Encoder, monitor, config.Talaria.CircuitTimeout, config.Talaria.MaxConcurrent, config.Talaria.ErrorPercentThreshold)
+			w, err := talaria.New(config.Talaria.Endpoint, config.Talaria.Filter, config.Talaria.Encoder, monitor, config.Talaria.CircuitTimeout, config.Talaria.MaxConcurrent, config.Talaria.ErrorPercentThreshold, config.Talaria.MaxCallSendMsgSize, config.Talaria.MaxCallRecvMsgSize)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
- Add grpc message size configuration for client and server. 
- Add default round-robin load balancing strategy for grpc client. 