### PR TITLE
Feat/nats multi table support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /go/src/talaria
 COPY . src/talaria
 RUN cd src/talaria && go build . && test -x talaria
 
-FROM debian:latest AS base
+FROM debian:bullseye AS base
 ARG MAINTAINER=roman.atachiants@gmail.com
 LABEL maintainer=${MAINTAINER}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,11 +107,15 @@ type S3SQS struct {
 
 // NATS represents NATS consumer configuration
 type NATS struct {
-	Subject string `json:"subject" yaml:"subject" env:"SUBJECT"`
-	Host    string `json:"host" yaml:"host" env:"HOST"`
-	Port    int32  `json:"port" yaml:"port" env:"PORT"`
-	Stream  string `json:"stream" yaml:"stream" env:"STREAM"`
-	Queue   string `json:"queue" yaml:"queue" env:"QUEUE"`
+	Host  string        `json:"host" yaml:"host" env:"HOST"`
+	Port  int32         `json:"port" yaml:"port" env:"PORT"`
+	Split []SplitWriter `json:"split" yaml:"split" env:"SPLIT"`
+}
+
+type SplitWriter struct {
+	Subject    string `json:"subject" yaml:"subject" env:"SUBJECT"`
+	Table      string `json:"table" yaml:"table" env:"TABLE"`
+	QueueGroup string `json:"queueGroup" yaml:"queueGroup" env:"QUEUE_GROUP"`
 }
 
 // Presto represents the Presto configuration

--- a/internal/ingress/nats/jetstream/client.go
+++ b/internal/ingress/nats/jetstream/client.go
@@ -1,0 +1,67 @@
+package jetstream
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/kelindar/talaria/internal/config"
+	"github.com/kelindar/talaria/internal/monitor"
+	"github.com/nats-io/nats.go"
+)
+
+type JSClient interface {
+	Subscribe(subj string, cb nats.MsgHandler, opts ...nats.SubOpt) (*nats.Subscription, error)
+	QueueSubscribe(subj, queue string, cb nats.MsgHandler, opts ...nats.SubOpt) (*nats.Subscription, error)
+	Publish(subj string, data []byte, opts ...nats.PubOpt) (*nats.PubAck, error)
+	// PublishMsg publishes a Msg to JetStream.
+	PublishMsg(m *nats.Msg, opts ...nats.PubOpt) (*nats.PubAck, error)
+	// AddStream creates a stream.
+	AddStream(cfg *nats.StreamConfig, opts ...nats.JSOpt) (*nats.StreamInfo, error)
+	// DeleteStream deletes a stream.
+	DeleteStream(name string, opts ...nats.JSOpt) error
+}
+
+type NatsClient interface {
+	Close()
+}
+
+type Client struct {
+	Context JSClient
+	Server  NatsClient
+}
+
+// Create new jetstream client.
+func New(conf *config.NATS, monitor monitor.Monitor) (*Client, error) {
+	nc, err := nats.Connect(fmt.Sprintf("%s:%d", conf.Host, conf.Port), nats.ReconnectHandler(func(_ *nats.Conn) {
+		log.Println("Successfully renonnect")
+	}), nats.ClosedHandler(func(nc *nats.Conn) {
+		log.Printf("Connection close due to %q", nc.LastError())
+		monitor.Error(nc.LastError())
+	}), nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
+		log.Printf("Got disconnected. Reason: %q\n", nc.LastError())
+		monitor.Error(nc.LastError())
+	}), nats.ErrorHandler(natsErrHandler))
+	if err != nil {
+		return nil, err
+	}
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return nil, err
+	}
+	client := &Client{js, nc}
+
+	return client, nil
+}
+
+func natsErrHandler(nc *nats.Conn, sub *nats.Subscription, natsErr error) {
+	if natsErr == nats.ErrSlowConsumer {
+		pendingMsgs, _, err := sub.Pending()
+		if err != nil {
+			log.Printf("couldn't get pending messages: %v", err)
+			return
+		}
+		log.Printf("Falling behind with %d pending messages on subject %q.\n",
+			pendingMsgs, sub.Subject)
+	}
+}

--- a/internal/ingress/nats/nats.go
+++ b/internal/ingress/nats/nats.go
@@ -3,148 +3,80 @@ package nats
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 
 	"github.com/kelindar/talaria/internal/config"
+	"github.com/kelindar/talaria/internal/ingress/nats/jetstream"
 	"github.com/kelindar/talaria/internal/monitor"
 	"github.com/kelindar/talaria/internal/monitor/errors"
 	"github.com/nats-io/nats.go"
 )
 
 const (
-	ctxTag = "NATS"
+	ctxTag          = "NATS"
+	tableNameHeader = "table"
 )
 
 type Ingress struct {
-	// jetstream exposed interface.
-	jetstream JetstreamI
-	monitor   monitor.Monitor
-	conn      *nats.Conn
-	queue     chan *nats.Msg
-	cancel    context.CancelFunc
-}
-
-type jetstream struct {
-	// The name of the queue group.
-	queue   string // The name of subject listening to.
-	subject string
-	// The jetstream context which provide jetstream api.
-	jsContext nats.JetStreamContext
-}
-
-type JetstreamI interface {
-	// Subscribe to defined subject from Nats server.
-	Subscribe(handler nats.MsgHandler) (*nats.Subscription, error)
-	Publish(msg []byte) (nats.PubAckFuture, error)
+	JSClient   jetstream.Client
+	queueGroup string
+	subject    string
+	monitor    monitor.Monitor
+	queue      chan *nats.Msg
+	cancel     context.CancelFunc
 }
 
 type Event map[string]interface{}
 
 // New create new ingestion from nats jetstream to sinks.
 func New(conf *config.NATS, monitor monitor.Monitor) (*Ingress, error) {
-	nc, err := nats.Connect(fmt.Sprintf("%s:%d", conf.Host, conf.Port), nats.ReconnectHandler(func(_ *nats.Conn) {
-		log.Println("Successfully renonnect")
-	}), nats.ClosedHandler(func(nc *nats.Conn) {
-		log.Printf("Connection close due to %q", nc.LastError())
-		monitor.Error(nc.LastError())
-	}), nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
-		log.Printf("Got disconnected. Reason: %q\n", nc.LastError())
-		monitor.Error(nc.LastError())
-	}), nats.ErrorHandler(natsErrHandler))
-	if err != nil {
-		return nil, err
-	}
-
-	js, err := NewJetStream(conf.Subject, conf.Queue, nc)
+	jsClient, err := jetstream.New(conf, monitor)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Ingress{
-		jetstream: js,
-		monitor:   monitor,
-		conn:      nc,
-		queue:     make(chan *nats.Msg, 100),
+		JSClient:   *jsClient,
+		monitor:    monitor,
+		queueGroup: conf.Queue,
+		subject:    conf.Subject,
+		queue:      make(chan *nats.Msg, 100),
 	}, nil
-}
-
-func natsErrHandler(nc *nats.Conn, sub *nats.Subscription, natsErr error) {
-	log.Printf("error: %v\n", natsErr)
-	if natsErr == nats.ErrSlowConsumer {
-		pendingMsgs, _, err := sub.Pending()
-		if err != nil {
-			log.Printf("couldn't get pending messages: %v", err)
-			return
-		}
-		log.Printf("Falling behind with %d pending messages on subject %q.\n",
-			pendingMsgs, sub.Subject)
-	}
-}
-
-// NewJetStream create Jetstream context
-func NewJetStream(subject, queue string, nc *nats.Conn) (*jetstream, error) {
-	js, err := nc.JetStream()
-	if err != nil {
-		return nil, err
-	}
-	return &jetstream{
-		subject:   subject,
-		queue:     queue,
-		jsContext: js,
-	}, nil
-}
-
-// Subscribe to a subject in nats server
-func (s *jetstream) Subscribe(handler nats.MsgHandler) (*nats.Subscription, error) {
-	// Queuesubscribe automatically create ephemeral push based consumer with queue group defined.
-	sb, err := s.jsContext.QueueSubscribe(s.subject, s.queue, handler)
-	if err != nil {
-		return nil, err
-	}
-	// set higher pending limits
-	sb.SetPendingLimits(65536, (1<<18)*1024)
-	_, b, _ := sb.PendingLimits()
-	log.Println("nats: maximum pending limits (bytes): ", b)
-	return sb, nil
-}
-
-// Publish message to the subject in nats server
-func (s *jetstream) Publish(msg []byte) (nats.PubAckFuture, error) {
-	p, err := s.jsContext.PublishAsync(s.subject, msg)
-	if err != nil {
-		return nil, err
-	}
-	return p, nil
 }
 
 // SubsribeHandler subscribes to specific subject and unmarshal the message into talaria's event type.
 // The event message then will be used as the input of the handler function defined.
-func (i *Ingress) SubsribeHandler(handler func(b []map[string]interface{})) error {
-	_, err := i.jetstream.Subscribe(func(msg *nats.Msg) {
+func (i *Ingress) SubsribeHandler(handler func(b []map[string]interface{}, table string)) error {
+	// Queuesubscribe automatically create ephemeral push based consumer with queue group defined.
+	sb, err := i.JSClient.Context.QueueSubscribe(i.subject, i.queueGroup, func(msg *nats.Msg) {
 		block := make([]map[string]interface{}, 0)
 		if err := json.Unmarshal(msg.Data, &block); err != nil {
 			i.monitor.Error(errors.Internal("nats: unable to unmarshal", err))
 		}
 		i.monitor.Count1(ctxTag, "NATS.subscribe.count")
-		handler(block)
+		// Get table name from header
+		table := msg.Header.Get(tableNameHeader)
+		handler(block, table)
 	})
 	if err != nil {
 		return err
 	}
+	// set higher pending limits
+	sb.SetPendingLimits(65536, (1<<18)*1024)
+	_, b, _ := sb.PendingLimits()
+	log.Println("nats: maximum pending limits (bytes): ", b)
 	return nil
 }
 
 // SubscribeHandlerWithPool process the message concurrently using goroutine pool.
 // The message will be asynchornously executed to reduce the message process time to avoid being slow consumer.
-func (i *Ingress) SubsribeHandlerWithPool(ctx context.Context, handler func(b []map[string]interface{})) error {
+func (i *Ingress) SubsribeHandlerWithPool(ctx context.Context, handler func(b []map[string]interface{}, split string)) error {
 	// Initialze pool
 	ctx, cancel := context.WithCancel(ctx)
 	i.cancel = cancel
 
 	i.initializeMemoryPool(ctx, handler)
-	_, err := i.jetstream.Subscribe(func(msg *nats.Msg) {
-		// Send the message to the queue
+	_, err := i.JSClient.Context.QueueSubscribe(i.subject, i.queueGroup, func(msg *nats.Msg) {
 		i.queue <- msg
 	})
 	if err != nil {
@@ -154,7 +86,7 @@ func (i *Ingress) SubsribeHandlerWithPool(ctx context.Context, handler func(b []
 }
 
 // Initialze memory pool for fixed number of goroutine to process the message
-func (i *Ingress) initializeMemoryPool(ctx context.Context, handler func(b []map[string]interface{})) {
+func (i *Ingress) initializeMemoryPool(ctx context.Context, handler func(b []map[string]interface{}, split string)) {
 	for n := 0; n < 100; n++ {
 		go func(n int, ctx context.Context, queue chan *nats.Msg) {
 			for {
@@ -168,8 +100,10 @@ func (i *Ingress) initializeMemoryPool(ctx context.Context, handler func(b []map
 						i.monitor.Error(errors.Internal("nats: unable to unmarshal", err))
 					}
 					i.monitor.Count1(ctxTag, "NATS.subscribe.count")
+					// Get table name from header
+					table := msg.Header.Get(tableNameHeader)
 					// asynchornously execute handler to reduce the message process time to avoid being slow consumer.
-					handler(block)
+					handler(block, table)
 				}
 			}
 		}(n, ctx, i.queue)
@@ -178,7 +112,7 @@ func (i *Ingress) initializeMemoryPool(ctx context.Context, handler func(b []map
 
 // Close ingress
 func (i *Ingress) Close() {
-	i.conn.Close()
+	i.JSClient.Server.Close()
 	i.cancel()
 	return
 }

--- a/internal/ingress/nats/nats.go
+++ b/internal/ingress/nats/nats.go
@@ -3,7 +3,7 @@ package nats
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"fmt"
 
 	"github.com/kelindar/talaria/internal/config"
 	"github.com/kelindar/talaria/internal/ingress/nats/jetstream"
@@ -18,15 +18,20 @@ const (
 )
 
 type Ingress struct {
-	JSClient   jetstream.Client
-	queueGroup string
-	subject    string
-	monitor    monitor.Monitor
-	queue      chan *nats.Msg
-	cancel     context.CancelFunc
+	JSClient jetstream.Client
+	monitor  monitor.Monitor
+	cancel   context.CancelFunc
+	split    []splitWriter
 }
 
 type Event map[string]interface{}
+
+type splitWriter struct {
+	subject    string
+	table      string
+	queueGroup string
+	queue      chan *nats.Msg
+}
 
 // New create new ingestion from nats jetstream to sinks.
 func New(conf *config.NATS, monitor monitor.Monitor) (*Ingress, error) {
@@ -35,36 +40,38 @@ func New(conf *config.NATS, monitor monitor.Monitor) (*Ingress, error) {
 		return nil, err
 	}
 
+	split := make([]splitWriter, len(conf.Split))
+	for i, s := range conf.Split {
+		split[i] = splitWriter{subject: s.Subject, table: s.Table, queue: make(chan *nats.Msg, 100), queueGroup: s.QueueGroup}
+	}
+
 	return &Ingress{
-		JSClient:   *jsClient,
-		monitor:    monitor,
-		queueGroup: conf.Queue,
-		subject:    conf.Subject,
-		queue:      make(chan *nats.Msg, 100),
+		JSClient: *jsClient,
+		monitor:  monitor,
+		split:    split,
 	}, nil
 }
 
 // SubsribeHandler subscribes to specific subject and unmarshal the message into talaria's event type.
 // The event message then will be used as the input of the handler function defined.
 func (i *Ingress) SubsribeHandler(handler func(b []map[string]interface{}, table string)) error {
-	// Queuesubscribe automatically create ephemeral push based consumer with queue group defined.
-	sb, err := i.JSClient.Context.QueueSubscribe(i.subject, i.queueGroup, func(msg *nats.Msg) {
-		block := make([]map[string]interface{}, 0)
-		if err := json.Unmarshal(msg.Data, &block); err != nil {
-			i.monitor.Error(errors.Internal("nats: unable to unmarshal", err))
+	for _, s := range i.split {
+		// Queuesubscribe automatically create ephemeral push based consumer with queue group defined.
+		sb, err := i.JSClient.Context.QueueSubscribe(s.subject, s.queueGroup, func(msg *nats.Msg) {
+			block := make([]map[string]interface{}, 0)
+			if err := json.Unmarshal(msg.Data, &block); err != nil {
+				i.monitor.Error(errors.Internal("nats: unable to unmarshal", err))
+			}
+			i.monitor.Count1(ctxTag, "NATS.subscribe.count")
+			handler(block, s.table)
+		})
+		if err != nil {
+			i.monitor.Error(err)
 		}
-		i.monitor.Count1(ctxTag, "NATS.subscribe.count")
-		// Get table name from header
-		table := msg.Header.Get(tableNameHeader)
-		handler(block, table)
-	})
-	if err != nil {
-		return err
+		// set higher pending limits
+		sb.SetPendingLimits(65536, (1<<18)*1024)
+		i.monitor.Info(fmt.Sprintf("%s->%s split created", s.subject, s.table))
 	}
-	// set higher pending limits
-	sb.SetPendingLimits(65536, (1<<18)*1024)
-	_, b, _ := sb.PendingLimits()
-	log.Println("nats: maximum pending limits (bytes): ", b)
 	return nil
 }
 
@@ -76,37 +83,42 @@ func (i *Ingress) SubsribeHandlerWithPool(ctx context.Context, handler func(b []
 	i.cancel = cancel
 
 	i.initializeMemoryPool(ctx, handler)
-	_, err := i.JSClient.Context.QueueSubscribe(i.subject, i.queueGroup, func(msg *nats.Msg) {
-		i.queue <- msg
-	})
-	if err != nil {
-		return err
+	for _, s := range i.split {
+		queue := s.queue
+		_, err := i.JSClient.Context.QueueSubscribe(s.subject, s.queueGroup, func(msg *nats.Msg) {
+			queue <- msg
+		})
+		if err != nil {
+			i.monitor.Error(fmt.Errorf("nats: queue subscribe error %v", err))
+			continue
+		}
+		i.monitor.Info(fmt.Sprintf("%s->%s split created", s.subject, s.table))
 	}
 	return nil
 }
 
 // Initialze memory pool for fixed number of goroutine to process the message
 func (i *Ingress) initializeMemoryPool(ctx context.Context, handler func(b []map[string]interface{}, split string)) {
-	for n := 0; n < 100; n++ {
-		go func(n int, ctx context.Context, queue chan *nats.Msg) {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case msg := <-queue:
-					// Wait for the message
-					block := make([]map[string]interface{}, 0)
-					if err := json.Unmarshal(msg.Data, &block); err != nil {
-						i.monitor.Error(errors.Internal("nats: unable to unmarshal", err))
+	for _, s := range i.split {
+		for n := 0; n < 100; n++ {
+			go func(n int, ctx context.Context, queue chan *nats.Msg, table string, sub string) {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case msg := <-queue:
+						// Wait for the message
+						block := make([]map[string]interface{}, 0)
+						if err := json.Unmarshal(msg.Data, &block); err != nil {
+							i.monitor.Error(errors.Internal("nats: unable to unmarshal", err))
+						}
+						i.monitor.Count1(ctxTag, "NATS.msg.count")
+						// asynchornously execute handler to reduce the message process time to avoid being slow consumer.
+						handler(block, table)
 					}
-					i.monitor.Count1(ctxTag, "NATS.subscribe.count")
-					// Get table name from header
-					table := msg.Header.Get(tableNameHeader)
-					// asynchornously execute handler to reduce the message process time to avoid being slow consumer.
-					handler(block, table)
 				}
-			}
-		}(n, ctx, i.queue)
+			}(n, ctx, s.queue, s.table, s.subject)
+		}
 	}
 }
 

--- a/internal/ingress/nats/nats_test_config.yaml
+++ b/internal/ingress/nats/nats_test_config.yaml
@@ -1,0 +1,8 @@
+writers:
+  nats:
+    host: nats://127.0.0.1
+    port: 8369
+    split:
+      - subject: event.talaria
+        queueGroup: talarias
+        table: event

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -185,13 +185,14 @@ func (s *Server) subscribeToJetStream(conf *config.Config) (err error) {
 
 	// Start ingesting
 	s.monitor.Info("server: starting ingestion from nats")
-	s.nats.SubsribeHandlerWithPool(context.Background(), func(block []map[string]interface{}) {
+	s.nats.SubsribeHandlerWithPool(context.Background(), func(block []map[string]interface{}, table string) {
 		data := strings.NewEncoder().Encode(block)
 
-		if _, err := s.Ingest(context.Background(), &talaria.IngestRequest{
-			Data: &talaria.IngestRequest_Batch{
+		if _, err := s.IngestWithTable(context.Background(), &talaria.IngestWithTableRequest{
+			Data: &talaria.IngestWithTableRequest_Batch{
 				Batch: data,
 			},
+			Tables: []string{table},
 		}); err != nil {
 			s.monitor.Warning(err)
 		}

--- a/internal/server/server_ingest.go
+++ b/internal/server/server_ingest.go
@@ -121,6 +121,7 @@ func (s *Server) IngestWithTable(ctx context.Context, request *talaria.IngestWit
 			return nil, errors.Internal("unable to read the block", err)
 		}
 
+		rowCount := 0
 		// If table supports streaming, then stream
 		if streamer, ok := t.(storage.Streamer); ok {
 			s := stream.Publish(streamer, s.monitor)
@@ -130,6 +131,7 @@ func (s *Server) IngestWithTable(ctx context.Context, request *talaria.IngestWit
 				if err != nil {
 					return nil, err
 				}
+				rowCount += len(rows)
 				for _, row := range rows {
 					_, err := s(row)
 					if err != nil {
@@ -148,7 +150,7 @@ func (s *Server) IngestWithTable(ctx context.Context, request *talaria.IngestWit
 			}
 		}
 
-		s.monitor.Count("server", fmt.Sprintf("%s.ingestWithTable.count", t.Name()), int64(len(blocks)))
+		s.monitor.Count("server", fmt.Sprintf("%s.ingestWithTable.count", t.Name()), int64(rowCount))
 	}
 
 	return nil, nil

--- a/internal/server/server_ingest.go
+++ b/internal/server/server_ingest.go
@@ -80,7 +80,6 @@ func (s *Server) Ingest(ctx context.Context, request *talaria.IngestRequest) (*t
 			}
 		}
 		s.monitor.Count("server", fmt.Sprintf("%s.ingest.row.count", t.Name()), int64(rowCount))
-		s.monitor.Count("server", fmt.Sprintf("%s.ingest.count", t.Name()), int64(len(blocks)))
 	}
 
 	return nil, nil

--- a/internal/storage/writer/gcs/gcs_test.go
+++ b/internal/storage/writer/gcs/gcs_test.go
@@ -15,6 +15,10 @@ func TestWriter(t *testing.T) {
 	c, err := New("test", "test", "", "", m)
 
 	// TODO: Impove test
-	assert.Nil(t, err)
-	assert.Error(t, c.Write(key.Key("test"), nil))
+	assert.Nil(t, c)
+	assert.Error(t, err)
+
+	assert.Panics(t, func() {
+		c.Write(key.Key("test"), nil)
+	})
 }

--- a/internal/storage/writer/gcs/gcs_test.go
+++ b/internal/storage/writer/gcs/gcs_test.go
@@ -15,10 +15,6 @@ func TestWriter(t *testing.T) {
 	c, err := New("test", "test", "", "", m)
 
 	// TODO: Impove test
-	assert.Nil(t, c)
-	assert.Error(t, err)
-
-	assert.Panics(t, func() {
-		c.Write(key.Key("test"), nil)
-	})
+	assert.Nil(t, err)
+	assert.Error(t, c.Write(key.Key("test"), nil))
 }


### PR DESCRIPTION
Add NATS jetstream multi-subject subscription support: 
* Each NATS subject has one-to-one mapping relation with a configured table which is called split
* Each split has its own consumer group/ queue group
* Each split has its own queue and 100 goroutine handling messages