### PR TITLE
add monitoring count for block during ingestion

### DIFF
--- a/internal/server/server_ingest.go
+++ b/internal/server/server_ingest.go
@@ -79,6 +79,7 @@ func (s *Server) Ingest(ctx context.Context, request *talaria.IngestRequest) (*t
 				return nil, err
 			}
 		}
+		s.monitor.Count("server", fmt.Sprintf("%s.ingest.block.count", t.Name()), int64(len(blocks)))
 		s.monitor.Count("server", fmt.Sprintf("%s.ingest.row.count", t.Name()), int64(rowCount))
 	}
 
@@ -150,6 +151,7 @@ func (s *Server) IngestWithTable(ctx context.Context, request *talaria.IngestWit
 			}
 		}
 
+		s.monitor.Count("server", fmt.Sprintf("%s.ingestWithTable.block.count", t.Name()), int64(len(blocks)))
 		s.monitor.Count("server", fmt.Sprintf("%s.ingestWithTable.count", t.Name()), int64(rowCount))
 	}
 


### PR DESCRIPTION
In the previous release, the block count was removed by accident. This PR add it back and also rename it to `ingest.block.count`. 